### PR TITLE
[fix]: image size

### DIFF
--- a/Sources/VersionIcon/VersionIconDefinitions.swift
+++ b/Sources/VersionIcon/VersionIconDefinitions.swift
@@ -205,7 +205,12 @@ func generateIcon(
     
     let version = getVersionText(appSetup: appSetup, designStyle: designStyle)
 
-    let newSize = CGSize(width: realSize.width / 2, height: realSize.height / 2)
+    let scaleFactor = NSScreen.main?.backingScaleFactor ?? 2
+
+    let newSize = CGSize(
+        width: realSize.width / scaleFactor,
+        height: realSize.height / scaleFactor
+    )
 
     //  Resizing ribbon
     let resizedRibbonImage = resizeImage(fileName: designStyle.ribbon, size: newSize)


### PR DESCRIPTION
This PR fixes an issue that the icon was half size on the MacStadium CI (512px instead of 1024px)

For more info about the scale factor, you can see the following link: https://stackoverflow.com/a/73094772